### PR TITLE
pytorch 0.4.1 fixes.

### DIFF
--- a/script/src/stnm.c
+++ b/script/src/stnm.c
@@ -6,25 +6,25 @@
 
 int BilinearSamplerBHWD_updateOutput(THFloatTensor *inputImages, THFloatTensor *grids, THFloatTensor *output)
 {
+  int batchsize = THFloatTensor_size(inputImages, 0);
+  int inputImages_height = THFloatTensor_size(inputImages, 1);
+  int inputImages_width = THFloatTensor_size(inputImages, 2);
+  int inputImages_channels = THFloatTensor_size(inputImages, 3);
+  int output_height = THFloatTensor_size(output, 1);
+  int output_width = THFloatTensor_size(output, 2);
 
-  int batchsize = inputImages->size[0];
-  int inputImages_height = inputImages->size[1];
-  int inputImages_width = inputImages->size[2];
-  int output_height = output->size[1];
-  int output_width = output->size[2];
-  int inputImages_channels = inputImages->size[3];
+  int output_strideBatch = THFloatTensor_stride(output,0);
+  int output_strideHeight = THFloatTensor_stride(output, 1);
+  int output_strideWidth = THFloatTensor_stride(output, 2);
 
-  int output_strideBatch = output->stride[0];
-  int output_strideHeight = output->stride[1];
-  int output_strideWidth = output->stride[2];
+  int inputImages_strideBatch = THFloatTensor_stride(inputImages, 0);
+  int inputImages_strideHeight = THFloatTensor_stride(inputImages, 1);
+  int inputImages_strideWidth = THFloatTensor_stride(inputImages, 2);
 
-  int inputImages_strideBatch = inputImages->stride[0];
-  int inputImages_strideHeight = inputImages->stride[1];
-  int inputImages_strideWidth = inputImages->stride[2];
+  int grids_strideBatch = THFloatTensor_stride(grids, 0);
+  int grids_strideHeight = THFloatTensor_stride(grids, 1);
+  int grids_strideWidth = THFloatTensor_stride(grids, 2);
 
-  int grids_strideBatch = grids->stride[0];
-  int grids_strideHeight = grids->stride[1];
-  int grids_strideWidth = grids->stride[2];
 
 
   real *inputImages_data, *output_data, *grids_data;
@@ -107,32 +107,33 @@ int BilinearSamplerBHWD_updateGradInput(THFloatTensor *inputImages, THFloatTenso
 {
   bool onlyGrid=false;
 
-  int batchsize = inputImages->size[0];
-  int inputImages_height = inputImages->size[1];
-  int inputImages_width = inputImages->size[2];
-  int gradOutput_height = gradOutput->size[1];
-  int gradOutput_width = gradOutput->size[2];
-  int inputImages_channels = inputImages->size[3];
+  int batchsize = THFloatTensor_size(inputImages, 0);
+  int inputImages_height = THFloatTensor_size(inputImages, 1);
+  int inputImages_width = THFloatTensor_size(inputImages, 2);
+  int inputImages_channels = THFloatTensor_size(inputImages, 3);
+  int gradOutput_height = THFloatTensor_size(gradOutput, 1);
+  int gradOutput_width = THFloatTensor_size(gradOutput, 2);
 
-  int gradOutput_strideBatch = gradOutput->stride[0];
-  int gradOutput_strideHeight = gradOutput->stride[1];
-  int gradOutput_strideWidth = gradOutput->stride[2];
+  int gradOutput_strideBatch = THFloatTensor_stride(gradOutput, 0);
+  int gradOutput_strideHeight = THFloatTensor_stride(gradOutput, 1);
+  int gradOutput_strideWidth = THFloatTensor_stride(gradOutput, 2);
 
-  int inputImages_strideBatch = inputImages->stride[0];
-  int inputImages_strideHeight = inputImages->stride[1];
-  int inputImages_strideWidth = inputImages->stride[2];
+  int inputImages_strideBatch = THFloatTensor_stride(inputImages, 0);
+  int inputImages_strideHeight = THFloatTensor_stride(inputImages, 1);
+  int inputImages_strideWidth = THFloatTensor_stride(inputImages, 2);
 
-  int gradInputImages_strideBatch = gradInputImages->stride[0];
-  int gradInputImages_strideHeight = gradInputImages->stride[1];
-  int gradInputImages_strideWidth = gradInputImages->stride[2];
-
-  int grids_strideBatch = grids->stride[0];
-  int grids_strideHeight = grids->stride[1];
-  int grids_strideWidth = grids->stride[2];
-
-  int gradGrids_strideBatch = gradGrids->stride[0];
-  int gradGrids_strideHeight = gradGrids->stride[1];
-  int gradGrids_strideWidth = gradGrids->stride[2];
+  int gradInputImages_strideBatch = THFloatTensor_stride(gradInputImages, 0);
+  int gradInputImages_strideHeight = THFloatTensor_stride(gradInputImages, 1);
+  int gradInputImages_strideWidth = THFloatTensor_stride(gradInputImages, 2);
+  
+  int grids_strideBatch = THFloatTensor_stride(grids, 0);
+  int grids_strideHeight = THFloatTensor_stride(grids, 1);
+  int grids_strideWidth = THFloatTensor_stride(grids, 2);
+  
+  int gradGrids_strideBatch = THFloatTensor_stride(gradGrids, 0);
+  int gradGrids_strideHeight = THFloatTensor_stride(gradGrids, 1);
+  int gradGrids_strideWidth = THFloatTensor_stride(gradGrids, 2);
+  
 
   real *inputImages_data, *gradOutput_data, *grids_data, *gradGrids_data, *gradInputImages_data;
   inputImages_data = THFloatTensor_data(inputImages);

--- a/script/src/stnm_cuda.c
+++ b/script/src/stnm_cuda.c
@@ -21,9 +21,9 @@ int BilinearSamplerBHWD_updateOutput_cuda(THCudaTensor *canvas, THCudaTensor *in
 //  THCudaTensor *output = (THCudaTensor *)luaT_checkudata(L, 4, "torch.CudaTensor");
 
   int success = 0;
-  success = BilinearSamplerBHWD_updateOutput_cuda_kernel(output->size[2],
-                                               output->size[1],
-                                               output->size[0],
+  success = BilinearSamplerBHWD_updateOutput_cuda_kernel(THCudaTensor_size(state, output, 2),
+                                               THCudaTensor_size(state, output, 1),
+                                               THCudaTensor_size(state, output, 0),
                                                THCudaTensor_data(state, inputImages),
                                                THCudaTensor_stride(state, inputImages, 0),
                                                THCudaTensor_stride(state, inputImages, 3),
@@ -74,9 +74,9 @@ int BilinearSamplerBHWD_updateGradInput_cuda(THCudaTensor *canvas, THCudaTensor 
 //  THCudaTensor *gradOutput = (THCudaTensor *)luaT_checkudata(L, 6, "torch.CudaTensor");
 
   int success = 0;
-  success = BilinearSamplerBHWD_updateGradInput_cuda_kernel(gradOutput->size[2],
-                                                  gradOutput->size[1],
-                                                  gradOutput->size[0],
+  success = BilinearSamplerBHWD_updateGradInput_cuda_kernel(THCudaTensor_size(state, gradOutput, 2),
+                                                  THCudaTensor_size(state, gradOutput, 1),
+                                                  THCudaTensor_size(state, gradOutput, 0),
                                                   THCudaTensor_data(state, inputImages),
                                                   THCudaTensor_stride(state, inputImages, 0),
                                                   THCudaTensor_stride(state, inputImages, 3),
@@ -146,9 +146,9 @@ int BilinearSamplerBHWD_updateGradInputOnlyGrid_cuda(THCudaTensor *inputImages, 
 
   int success = 0;
   success = BilinearSamplerBHWD_updateGradInputOnlyGrid_cuda_kernel(
-                                                  gradOutput->size[2],
-                                                  gradOutput->size[1],
-                                                  gradOutput->size[0],
+                                                  THCudaTensor_size(state, gradOutput, 2),
+                                                  THCudaTensor_size(state, gradOutput, 1),
+                                                  THCudaTensor_size(state, gradOutput, 0),
                                                   THCudaTensor_size(state, inputImages, 3),
                                                   THCudaTensor_size(state, inputImages, 1),
                                                   THCudaTensor_size(state, inputImages, 2),


### PR DESCRIPTION
In 0.4.1 interface of ATen was changed. Now size and stride properties can be accessed only through `THFloatTensor_stride` and `THFloatTensor_size` functions.